### PR TITLE
Tell users to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 This is a package just to be able to use openssl with SwiftPM.
 To use this package, add this to your `Package.swift` in `dependencies`:
 
-    .package(url: "git@github.com:apple/swift-nio-ssl-support.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"),
 


### PR DESCRIPTION
Motivation:

Users should use https when declaring a dependency as otherwise an account is needed.

Modifications:

Replace git url with https

Result:

Easier usage of dependency